### PR TITLE
Clarified ptw/tlb/sret/cache I/O bundles

### DIFF
--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -675,6 +675,7 @@ class Control extends CoreModule
   io.dmem.req.bits.cmd  := ex_ctrl.mem_cmd
   io.dmem.req.bits.typ  := ex_ctrl.mem_type
   io.dmem.req.bits.phys := Bool(false)
+  io.dmem.sret          := io.dpath.sret
 
   io.rocc.cmd.valid := wb_rocc_val
   io.rocc.exception := wb_reg_xcpt && sr.er

--- a/src/main/scala/dpath.scala
+++ b/src/main/scala/dpath.scala
@@ -177,7 +177,6 @@ class Datapath extends CoreModule
 
   io.ptw.ptbr := pcr.io.ptbr
   io.ptw.invalidate := pcr.io.fatc
-  io.ptw.sret := io.ctrl.sret
   io.ptw.status := pcr.io.status
 
   // memory stage

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -83,6 +83,7 @@ class HellaCacheIO extends CoreBundle {
   val resp = Valid(new HellaCacheResp).flip
   val replay_next = Valid(Bits(width = coreDCacheReqTagBits)).flip
   val xcpt = (new HellaCacheExceptions).asInput
+  val sret = Bool(OUTPUT)
   val ordered = Bool(INPUT)
 }
 
@@ -750,7 +751,7 @@ class HellaCache extends L1HellaCacheModule {
       lrsc_count := 0
     }
   }
-  when (io.ptw.sret) { lrsc_count := 0 }
+  when (io.cpu.sret) { lrsc_count := 0 }
 
   val s2_data = Vec.fill(nWays){Bits(width = encRowBits)}
   for (w <- 0 until nWays) {

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -83,7 +83,6 @@ class HellaCacheIO extends CoreBundle {
   val resp = Valid(new HellaCacheResp).flip
   val replay_next = Valid(Bits(width = coreDCacheReqTagBits)).flip
   val xcpt = (new HellaCacheExceptions).asInput
-  val ptw = new TLBPTWIO().flip
   val ordered = Bool(INPUT)
 }
 
@@ -596,6 +595,7 @@ class DataArray extends L1HellaCacheModule {
 class HellaCache extends L1HellaCacheModule {
   val io = new Bundle {
     val cpu = (new HellaCacheIO).flip
+    val ptw = new TLBPTWIO()
     val mem = new TileLinkIO
   }
  
@@ -634,7 +634,7 @@ class HellaCache extends L1HellaCacheModule {
   val s1_readwrite = s1_read || s1_write || isPrefetch(s1_req.cmd)
 
   val dtlb = Module(new TLB)
-  dtlb.io.ptw <> io.cpu.ptw
+  dtlb.io.ptw <> io.ptw
   dtlb.io.req.valid := s1_valid_masked && s1_readwrite && !s1_req.phys
   dtlb.io.req.bits.passthrough := s1_req.phys
   dtlb.io.req.bits.asid := UInt(0)
@@ -750,7 +750,7 @@ class HellaCache extends L1HellaCacheModule {
       lrsc_count := 0
     }
   }
-  when (io.cpu.ptw.sret) { lrsc_count := 0 }
+  when (io.ptw.sret) { lrsc_count := 0 }
 
   val s2_data = Vec.fill(nWays){Bits(width = encRowBits)}
   for (w <- 0 until nWays) {

--- a/src/main/scala/ptw.scala
+++ b/src/main/scala/ptw.scala
@@ -17,13 +17,11 @@ class TLBPTWIO extends CoreBundle {
   val resp = Valid(new PTWResp).flip
   val status = new Status().asInput
   val invalidate = Bool(INPUT)
-  val sret = Bool(INPUT)
 }
 
 class DatapathPTWIO extends CoreBundle {
   val ptbr = UInt(INPUT, paddrBits)
   val invalidate = Bool(INPUT)
-  val sret = Bool(INPUT)
   val status = new Status().asInput
 }
 
@@ -83,7 +81,6 @@ class PTW(n: Int) extends CoreModule
     io.requestor(i).resp.bits.perm := r_pte(8,3)
     io.requestor(i).resp.bits.ppn := resp_ppn.toUInt
     io.requestor(i).invalidate := io.dpath.invalidate
-    io.requestor(i).sret := io.dpath.sret
     io.requestor(i).status := io.dpath.status
   }
 

--- a/src/main/scala/tile.scala
+++ b/src/main/scala/tile.scala
@@ -31,8 +31,8 @@ class RocketTile(resetSignal: Bool = null) extends Tile(resetSignal) {
   dcArb.io.requestor(1) <> core.io.dmem
   dcArb.io.mem <> dcache.io.cpu
 
-  ptw.io.requestor(0) <> icache.io.cpu.ptw
-  ptw.io.requestor(1) <> dcache.io.cpu.ptw
+  ptw.io.requestor(0) <> icache.io.ptw
+  ptw.io.requestor(1) <> dcache.io.ptw
 
   core.io.host <> io.host
   core.io.imem <> icache.io.cpu


### PR DESCRIPTION
I felt the ptw interfacing was a bit confusing; I have now clarified the I/O bundles and made ptw a first-class citizen of the cache I/Os. I also removed "sret" from the ptw, which only served as a pass-through to the dcache's LR/SC logic. The core's ctrl code now directly hands the dcache the "sret" signal. 