### PR TITLE
Rocket front-end can now fetch 4 instructions; added assert to dcache; refactoring

### DIFF
--- a/src/main/scala/consts.scala
+++ b/src/main/scala/consts.scala
@@ -21,7 +21,7 @@ trait ScalarOpConstants {
   val PC_EX  = UInt(0, 2)
   val PC_MEM = UInt(1, 2)
   val PC_WB  = UInt(2, 2)
-  val PC_PCR = UInt(3, 2)
+  val PC_CSR = UInt(3, 2)
 
   val A1_X    = Bits("b??", 2)
   val A1_ZERO = UInt(0, 2)

--- a/src/main/scala/csr.scala
+++ b/src/main/scala/csr.scala
@@ -93,7 +93,6 @@ class CSRFileIO extends CoreBundle {
   val uarch_counters = Vec.fill(16)(UInt(INPUT, log2Up(1+retireWidth)))
   val custom_mrw_csrs = Vec.fill(params(NCustomMRWCSRs))(UInt(INPUT, xLen))
   val cause = UInt(INPUT, xLen)
-  val mbadaddr_wen = Bool(INPUT)
   val pc = SInt(INPUT, vaddrBits+1)
   val fatc = Bool(OUTPUT)
   val time = UInt(OUTPUT, xLen)

--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -674,7 +674,7 @@ class Control extends CoreModule
   io.dmem.req.bits.cmd  := ex_ctrl.mem_cmd
   io.dmem.req.bits.typ  := ex_ctrl.mem_type
   io.dmem.req.bits.phys := Bool(false)
-  io.dmem.sret := wb_xcpt // obviously not an sret, but sufficient
+  io.dmem.invalidate_lr := wb_xcpt
 
   io.rocc.cmd.valid := wb_rocc_val
   io.rocc.exception := wb_xcpt && io.dpath.status.xs.orR

--- a/src/main/scala/ctrl.scala
+++ b/src/main/scala/ctrl.scala
@@ -553,7 +553,7 @@ class Control extends CoreModule
   take_pc_wb := replay_wb || wb_xcpt || io.dpath.eret
 
   io.dpath.sel_pc :=
-    Mux(wb_xcpt || io.dpath.eret,     PC_PCR, // exception or [m|s]ret
+    Mux(wb_xcpt || io.dpath.eret,     PC_CSR, // exception or [m|s]ret
     Mux(replay_wb,                    PC_WB,  // replay
                                       PC_MEM))
 
@@ -589,7 +589,7 @@ class Control extends CoreModule
     io.dpath.bypass_src(i) := PriorityEncoder(doBypass(i))
   }
 
-  // stall for RAW/WAW hazards on PCRs, loads, AMOs, and mul/div in execute stage.
+  // stall for RAW/WAW hazards on CSRs, loads, AMOs, and mul/div in execute stage.
   val id_renx1_not0 = id_ctrl.rxs1 && id_raddr1 != UInt(0)
   val id_renx2_not0 = id_ctrl.rxs2 && id_raddr2 != UInt(0)
   val id_wen_not0 = id_ctrl.wxd && id_waddr != UInt(0)
@@ -605,7 +605,7 @@ class Control extends CoreModule
      io.fpu.dec.wen  && id_waddr  === io.dpath.ex_waddr)
   val id_ex_hazard = ex_reg_valid && (data_hazard_ex && ex_cannot_bypass || fp_data_hazard_ex)
 
-  // stall for RAW/WAW hazards on PCRs, LB/LH, and mul/div in memory stage.
+  // stall for RAW/WAW hazards on CSRs, LB/LH, and mul/div in memory stage.
   val mem_mem_cmd_bh =
     if (params(FastLoadWord)) Bool(!params(FastLoadByte)) && mem_reg_slow_bypass
     else Bool(true)

--- a/src/main/scala/icache.scala
+++ b/src/main/scala/icache.scala
@@ -114,13 +114,11 @@ class Frontend(btb_updates_out_of_order: Boolean = false) extends FrontendModule
   io.cpu.resp.valid := s2_valid && (s2_xcpt_if || icache.io.resp.valid)
   io.cpu.resp.bits.pc := s2_pc
 
-  var fetch_data:Bits = null
-  require (coreFetchWidth <= 4)
-  if (coreFetchWidth == 4) {
-    fetch_data = icache.io.resp.bits.datablock
-  } else {
-    fetch_data = icache.io.resp.bits.datablock >> (s2_pc(log2Up(rowBytes)-1,log2Up(coreFetchWidth*coreInstBytes)) << log2Up(coreFetchWidth*coreInstBits))
-  }
+  require(coreFetchWidth * coreInstBytes <= rowBytes)
+  val fetch_data =
+    if (coreFetchWidth * coreInstBytes == rowBytes) icache.io.resp.bits.datablock
+    else icache.io.resp.bits.datablock >> (s2_pc(log2Up(rowBytes)-1,log2Up(coreFetchWidth*coreInstBytes)) << log2Up(coreFetchWidth*coreInstBits))
+
   for (i <- 0 until coreFetchWidth) {
     io.cpu.resp.bits.data(i) := fetch_data(i*coreInstBits+coreInstBits-1, i*coreInstBits)
   }

--- a/src/main/scala/icache.scala
+++ b/src/main/scala/icache.scala
@@ -114,8 +114,13 @@ class Frontend(btb_updates_out_of_order: Boolean = false) extends FrontendModule
   io.cpu.resp.valid := s2_valid && (s2_xcpt_if || icache.io.resp.valid)
   io.cpu.resp.bits.pc := s2_pc
 
-
-  val fetch_data = icache.io.resp.bits.datablock >> (s2_pc(log2Up(rowBytes)-1,log2Up(coreFetchWidth*coreInstBytes)) << log2Up(coreFetchWidth*coreInstBits))
+  var fetch_data:Bits = null
+  require (coreFetchWidth <= 4)
+  if (coreFetchWidth == 4) {
+    fetch_data = icache.io.resp.bits.datablock
+  } else {
+    fetch_data = icache.io.resp.bits.datablock >> (s2_pc(log2Up(rowBytes)-1,log2Up(coreFetchWidth*coreInstBytes)) << log2Up(coreFetchWidth*coreInstBits))
+  }
   for (i <- 0 until coreFetchWidth) {
     io.cpu.resp.bits.data(i) := fetch_data(i*coreInstBits+coreInstBits-1, i*coreInstBits)
   }

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -83,7 +83,7 @@ class HellaCacheIO extends CoreBundle {
   val resp = Valid(new HellaCacheResp).flip
   val replay_next = Valid(Bits(width = coreDCacheReqTagBits)).flip
   val xcpt = (new HellaCacheExceptions).asInput
-  val sret = Bool(OUTPUT)
+  val invalidate_lr = Bool(OUTPUT)
   val ordered = Bool(INPUT)
 }
 
@@ -752,7 +752,7 @@ class HellaCache extends L1HellaCacheModule {
       lrsc_count := 0
     }
   }
-  when (io.cpu.sret) { lrsc_count := 0 }
+  when (io.cpu.invalidate_lr) { lrsc_count := 0 }
 
   val s2_data = Vec.fill(nWays){Bits(width = encRowBits)}
   for (w <- 0 until nWays) {

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -686,6 +686,10 @@ class HellaCache extends L1HellaCacheModule {
   io.cpu.xcpt.pf.ld := s1_read && dtlb.io.resp.xcpt_ld
   io.cpu.xcpt.pf.st := s1_write && dtlb.io.resp.xcpt_st
 
+  assert (!(Reg(next=
+    (io.cpu.xcpt.ma.ld || io.cpu.xcpt.ma.st || io.cpu.xcpt.pf.ld || io.cpu.xcpt.pf.st)) &&
+    io.cpu.resp.valid), "DCache exception occurred - cache response not killed.")
+
   // tags
   def onReset = L1Metadata(UInt(0), ClientMetadata.onReset)
   val meta = Module(new MetadataArray(onReset _))

--- a/src/main/scala/rocc.scala
+++ b/src/main/scala/rocc.scala
@@ -123,7 +123,7 @@ class AccumulatorExample extends RoCC
   io.mem.req.bits.cmd := M_XRD // perform a load (M_XWR for stores)
   io.mem.req.bits.typ := MT_D // D = 8 bytes, W = 4, H = 2, B = 1
   io.mem.req.bits.data := Bits(0) // we're not performing any stores...
-  io.mem.sret := false
+  io.mem.invalidate_lr := false
 
   io.imem.acquire.valid := false
   io.imem.grant.ready := false

--- a/src/main/scala/tile.scala
+++ b/src/main/scala/tile.scala
@@ -25,7 +25,7 @@ class RocketTile(resetSignal: Bool = null) extends Tile(resetSignal) {
   val ptw = Module(new PTW(params(NPTWPorts)))
   val core = Module(new Core, { case CoreName => "Rocket" })
 
-  dcache.io.cpu.sret := core.io.dmem.sret // Bypass sret to dcache
+  dcache.io.cpu.invalidate_lr := core.io.dmem.invalidate_lr // Bypass signal to dcache
   val dcArb = Module(new HellaCacheArbiter(params(NDCachePorts)))
   dcArb.io.requestor(0) <> ptw.io.mem
   dcArb.io.requestor(1) <> core.io.dmem


### PR DESCRIPTION
* The most important change is Rocket's front-end can now fetch 4-wide.
* Added assert() to catch if the core doesn't kill a cache request when a memory exception occurs
* renamed PCR to CSR
* renamed dmem.sret to invalidate_lr
* removed unused mbadaddr_wen in the CSR I/O
