### PR TITLE
L1 D$ writeback unit, reduce re-read data array

### DIFF
--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -409,11 +409,13 @@ class WritebackUnit extends L1HellaCacheModule {
     }
     when (r2_data_req_fired) {
       io.release.valid := beat_done
-      when(!io.release.ready) {
-        r1_data_req_fired := false
-        r2_data_req_fired := false
-        data_req_cnt := data_req_cnt - Mux[UInt](Bool(refillCycles > 1) && r1_data_req_fired, 2, 1)
-      } .elsewhen(beat_done) { if(refillCyclesPerBeat > 1) buf_v := 0 }
+      when(beat_done) {
+        when(!io.release.ready) {
+          r1_data_req_fired := false
+          r2_data_req_fired := false
+          data_req_cnt := data_req_cnt - Mux[UInt](Bool(refillCycles > 1) && r1_data_req_fired, 2, 1)
+        } .otherwise { if(refillCyclesPerBeat > 1) buf_v := 0 }
+      }
       when(!r1_data_req_fired) {
         // We're done if this is the final data request and the Release can be sent
         active := data_req_cnt < UInt(refillCycles) || !io.release.ready

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -882,7 +882,7 @@ class HellaCache extends L1HellaCacheModule {
 
   val s2_recycle_ecc = (s2_valid || s2_replay) && s2_hit && s2_data_correctable
   val s2_recycle_next = Reg(init=Bool(false))
-  when (s1_valid || s1_replay) { s2_recycle_next := (s1_valid || s1_replay) && s2_recycle_ecc }
+  when (s1_valid || s1_replay) { s2_recycle_next := s2_recycle_ecc }
   s2_recycle := s2_recycle_ecc || s2_recycle_next
 
   // after a nack, block until nack condition resolves to save energy


### PR DESCRIPTION
When io.release.ready drops and beat_done is also low, there is no need to reread data array (reduce data_req_cnt).