### PR TITLE
Bypass L1 DCache for Memory-Mapped IO

### DIFF
--- a/src/main/scala/csr.scala
+++ b/src/main/scala/csr.scala
@@ -156,21 +156,21 @@ class CSRFile extends CoreModule
   val host_pcr_req_valid = Reg(Bool()) // don't reset
   val host_pcr_req_fire = host_pcr_req_valid && !cpu_ren
   val host_pcr_rep_valid = Reg(Bool()) // don't reset
-  val host_pcr_bits = Reg(io.host.pcr_req.bits)
-  io.host.pcr_req.ready := !host_pcr_req_valid && !host_pcr_rep_valid
-  io.host.pcr_rep.valid := host_pcr_rep_valid
-  io.host.pcr_rep.bits := host_pcr_bits.data
-  when (io.host.pcr_req.fire()) {
+  val host_pcr_bits = Reg(io.host.pcr.req.bits)
+  io.host.pcr.req.ready := !host_pcr_req_valid && !host_pcr_rep_valid
+  io.host.pcr.resp.valid := host_pcr_rep_valid
+  io.host.pcr.resp.bits := host_pcr_bits.data
+  when (io.host.pcr.req.fire()) {
     host_pcr_req_valid := true
-    host_pcr_bits := io.host.pcr_req.bits
+    host_pcr_bits := io.host.pcr.req.bits
   }
   when (host_pcr_req_fire) {
     host_pcr_req_valid := false
     host_pcr_rep_valid := true
     host_pcr_bits.data := io.rw.rdata
   }
-  when (io.host.pcr_rep.fire()) { host_pcr_rep_valid := false }
-  
+  when (io.host.pcr.resp.fire()) { host_pcr_rep_valid := false }
+
   io.host.debug_stats_pcr := reg_stats // direct export up the hierarchy
 
   val read_mstatus = io.status.toBits
@@ -411,7 +411,7 @@ class CSRFile extends CoreModule
     when (decoded_addr(CSRs.mbadaddr)) { reg_mbadaddr := wdata(vaddrBitsExtended-1,0) }
     when (decoded_addr(CSRs.instretw)) { reg_instret := wdata }
     when (decoded_addr(CSRs.mtimecmp)) { reg_mtimecmp := wdata; reg_mip.mtip := false }
-    when (decoded_addr(CSRs.mreset) /* XXX used by HTIF to write mtime */) { reg_time := wdata }
+    when (decoded_addr(CSRs.mtime))    { reg_time := wdata }
     when (decoded_addr(CSRs.mfromhost)){ when (reg_fromhost === UInt(0) || !host_pcr_req_fire) { reg_fromhost := wdata } }
     when (decoded_addr(CSRs.mtohost))  { when (reg_tohost === UInt(0) || host_pcr_req_fire) { reg_tohost := wdata } }
     when (decoded_addr(CSRs.stats))    { reg_stats := wdata(0) }

--- a/src/main/scala/icache.scala
+++ b/src/main/scala/icache.scala
@@ -106,7 +106,9 @@ class Frontend(btb_updates_out_of_order: Boolean = false) extends FrontendModule
   icache.io.req.bits.idx := io.cpu.npc
   icache.io.invalidate := io.cpu.invalidate
   icache.io.req.bits.ppn := tlb.io.resp.ppn
-  icache.io.req.bits.kill := io.cpu.req.valid || tlb.io.resp.miss || icmiss || io.ptw.invalidate
+  icache.io.req.bits.kill := io.cpu.req.valid ||
+    tlb.io.resp.miss || tlb.io.resp.xcpt_if ||
+    icmiss || io.ptw.invalidate
   icache.io.resp.ready := !stall && !s1_same_block
 
   io.cpu.resp.valid := s2_valid && (s2_xcpt_if || icache.io.resp.valid)

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -32,7 +32,6 @@ abstract trait L1HellaCacheParameters extends L1CacheParameters {
   val sdqDepth = params(StoreDataQueueDepth)
   val nMSHRs = params(NMSHRs)
   val nIOMSHRs = params(NIOMSHRs)
-  val mmioBase = params(MMIOBase)
 }
 
 abstract class L1HellaCacheBundle extends Bundle with L1HellaCacheParameters
@@ -788,8 +787,8 @@ class HellaCache extends L1HellaCacheModule {
     
   io.cpu.xcpt.ma.ld := s1_read && misaligned
   io.cpu.xcpt.ma.st := s1_write && misaligned
-  io.cpu.xcpt.pf.ld := !s1_req.phys && s1_read && dtlb.io.resp.xcpt_ld
-  io.cpu.xcpt.pf.st := !s1_req.phys && s1_write && dtlb.io.resp.xcpt_st
+  io.cpu.xcpt.pf.ld := s1_read && dtlb.io.resp.xcpt_ld
+  io.cpu.xcpt.pf.st := s1_write && dtlb.io.resp.xcpt_st
 
   assert (!(Reg(next=
     (io.cpu.xcpt.ma.ld || io.cpu.xcpt.ma.st || io.cpu.xcpt.pf.ld || io.cpu.xcpt.pf.st)) &&

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -42,6 +42,7 @@ abstract trait CoreParameters extends UsesParameters {
   val coreDCacheReqTagBits = params(CoreDCacheReqTagBits)
   val coreMaxAddrBits = math.max(ppnBits,vpnBits+1) + pgIdxBits
   val vaddrBitsExtended = vaddrBits + (vaddrBits < xLen).toInt
+  val mmioBase = params(MMIOBase)
 
   // Print out log of committed instructions and their writeback values.
   // Requires post-processing due to out-of-order writebacks.

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -167,8 +167,8 @@ class Rocket extends CoreModule
     (id_illegal_insn,           UInt(Causes.illegal_instruction))))
 
   val dcache_bypass_data =
-    if(params(FastLoadByte)) io.dmem.resp.bits.data_subword
-    else if(params(FastLoadWord)) io.dmem.resp.bits.data
+    if(params(FastLoadByte)) io.dmem.resp.bits.data
+    else if(params(FastLoadWord)) io.dmem.resp.bits.data_word_bypass
     else wb_reg_wdata
 
   // detect bypass opportunities
@@ -364,7 +364,7 @@ class Rocket extends CoreModule
   val wb_wen = wb_valid && wb_ctrl.wxd
   val rf_wen = wb_wen || ll_wen 
   val rf_waddr = Mux(ll_wen, ll_waddr, wb_waddr)
-  val rf_wdata = Mux(dmem_resp_valid && dmem_resp_xpu, io.dmem.resp.bits.data_subword,
+  val rf_wdata = Mux(dmem_resp_valid && dmem_resp_xpu, io.dmem.resp.bits.data,
                  Mux(ll_wen, ll_wdata,
                  Mux(wb_ctrl.csr != CSR.N, csr.io.rw.rdata,
                  wb_reg_wdata)))
@@ -474,7 +474,7 @@ class Rocket extends CoreModule
   io.fpu.inst := id_inst
   io.fpu.fromint_data := ex_rs(0)
   io.fpu.dmem_resp_val := dmem_resp_valid && dmem_resp_fpu
-  io.fpu.dmem_resp_data := io.dmem.resp.bits.data
+  io.fpu.dmem_resp_data := io.dmem.resp.bits.data_word_bypass
   io.fpu.dmem_resp_type := io.dmem.resp.bits.typ
   io.fpu.dmem_resp_tag := dmem_resp_waddr
 


### PR DESCRIPTION
This PR implements bypassing of the L1 data cache in order to support Memory-Mapped IO. Accesses to physical memory addresses above MMIOBase are no longer cached in the data array.

Also included are changes to the HTIF interface and CSRs in order to conform to the HTIF changes made in uncore.