### PR TITLE
Add calls to setMemName to fix SRAM names for VLSI

### DIFF
--- a/src/main/scala/icache.scala
+++ b/src/main/scala/icache.scala
@@ -197,6 +197,7 @@ class ICache extends FrontendModule
   val repl_way = if (isDM) UInt(0) else LFSR16(s2_miss)(log2Up(nWays)-1,0)
   val entagbits = code.width(tagBits)
   val tag_array = SeqMem(Bits(width = entagbits*nWays), nSets)
+  tag_array.setMemName("ICache_Tag_Array_Mem")
   val tag_rdata = tag_array.read(s0_pgoff(untagBits-1,blockOffBits), !refill_done && s0_valid)
   when (refill_done) {
     val wmask = FillInterleaved(entagbits, if (isDM) Bits(1) else UIntToOH(repl_way))
@@ -239,6 +240,7 @@ class ICache extends FrontendModule
 
   for (i <- 0 until nWays) {
     val data_array = SeqMem(Bits(width = code.width(rowBits)), nSets*refillCycles)
+    data_array.setMemName("ICache_Data_Array_Mem")
     val wen = narrow_grant.valid && repl_way === UInt(i)
     when (wen) {
       val e_d = code.encode(narrow_grant.bits.data).toUInt

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -552,6 +552,7 @@ class DataArray extends L1HellaCacheModule {
       val r_raddr = RegEnable(io.read.bits.addr, io.read.valid)
       for (p <- 0 until resp.size) {
         val array = SeqMem(Bits(width=encRowBits), nSets*refillCycles)
+        array.setMemName("NBDCache_Data_Array_Mem_" + p)
         when (wway_en.orR && io.write.valid && io.write.bits.wmask(p)) {
           val data = Fill(rowWords, io.write.bits.data(encDataBits*(p+1)-1,encDataBits*p))
           val mask = FillInterleaved(encDataBits, wway_en)
@@ -571,6 +572,7 @@ class DataArray extends L1HellaCacheModule {
     val wmask = FillInterleaved(encDataBits, io.write.bits.wmask)
     for (w <- 0 until nWays) {
       val array = SeqMem(Bits(width=encRowBits), nSets*refillCycles)
+      array.setMemName("NBDCache_Data_Array_Mem")
       when (io.write.bits.way_en(w) && io.write.valid) {
         array.write(waddr, io.write.bits.data, wmask)
       }


### PR DESCRIPTION
This allows for predictable naming of the internal `Mem`s inside `SeqMem`s and helps with the scriptability of the VLSI flow.

This requires chisel >= ucb-bar/chisel@8f37a8e; all repos needing `setMemName`-related patches will get bumped in rocket-chip.