### PR TITLE
Fix bug in BTB, regarding global history+replays

### DIFF
--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -526,7 +526,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
   when (com_br_valid) {
     com_global_history := Cat(com_br_taken, com_global_history(nbhtbits-1,1))
   }
-  io.imem.bht_update.bits.rollback.valid := mem_reg_replay
+  io.imem.bht_update.bits.rollback.valid := Bool(false) //roll-back disabled! //mem_reg_replay
   io.imem.bht_update.bits.rollback.bits.history := com_global_history
 
 

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -516,6 +516,20 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
   io.imem.ras_update.bits.isReturn := io.imem.btb_update.bits.isReturn
   io.imem.ras_update.bits.prediction := io.imem.btb_update.bits.prediction
 
+  // maintain a copy of the committed global history for the BHT. On a pipeline
+  // reset, rollback the history to clear any speculative updates. The BHT only
+  // tracks branches that were a hit in the BTB.
+  val nbhtbits = log2Up(p(BtbKey).nEntries).max(1)
+  val com_global_history = Reg(Bits(width = nbhtbits))
+  val com_br_valid = io.imem.bht_update.valid && io.imem.bht_update.bits.prediction.valid
+  val com_br_taken = io.imem.bht_update.bits.taken
+  when (com_br_valid) {
+    com_global_history := Cat(com_br_taken, com_global_history(nbhtbits-1,1))
+  }
+  io.imem.bht_update.bits.rollback.valid := mem_reg_replay
+  io.imem.bht_update.bits.rollback.bits.history := com_global_history
+
+
   io.fpu.valid := !ctrl_killd && id_ctrl.fp
   io.fpu.killx := ctrl_killx
   io.fpu.killm := killm_common


### PR DESCRIPTION
   * global history is updated speculatively in fetch
   * a copy of global history is given to each branch, so mispredicts can properly reset history
   * however, pipeline replays do NOT reset history, causing the BHT to unlearn the history
   * The fix is to add a "commit" copy of the global history, tracked in the rocket datapath
   * And on a pipeline flush, the commit copy is copied back to the global history