### PR TITLE
Rocc FPU fixup

### DIFF
--- a/src/main/scala/rocc.scala
+++ b/src/main/scala/rocc.scala
@@ -47,7 +47,7 @@ class RoCCInterface(implicit p: Parameters) extends CoreBundle()(p) {
   val resp = Decoupled(new RoCCResponse)
   val mem = new HellaCacheIO()(p.alterPartial({ case CacheName => "L1D" }))
   val busy = Bool(OUTPUT)
-  val s = Bool(INPUT)
+  val status = new MStatus().asInput
   val interrupt = Bool(OUTPUT)
   
   // These should be handled differently, eventually

--- a/src/main/scala/rocc.scala
+++ b/src/main/scala/rocc.scala
@@ -54,8 +54,7 @@ class RoCCInterface(implicit p: Parameters) extends CoreBundle()(p) {
   val autl = new ClientUncachedTileLinkIO
   val utl = Vec(p(RoccNMemChannels), new ClientUncachedTileLinkIO)
   val ptw = Vec(p(RoccNPTWPorts), new TLBPTWIO)
-  val fpu_req = Decoupled(new FPInput)
-  val fpu_resp = Decoupled(new FPResult).flip
+  val fpu = new FPSideIO
   val exception = Bool(INPUT)
   val csr = (new RoCCCSRs).flip
   val host_id = UInt(INPUT, log2Up(nCores))

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -539,7 +539,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
 
   io.rocc.cmd.valid := wb_rocc_val
   io.rocc.exception := wb_xcpt && csr.io.status.xs.orR
-  io.rocc.s := csr.io.status.prv.orR // should we just pass all of mstatus?
+  io.rocc.status := csr.io.status
   io.rocc.cmd.bits.inst := new RoCCInstruction().fromBits(wb_reg_inst)
   io.rocc.cmd.bits.rs1 := wb_reg_wdata
   io.rocc.cmd.bits.rs2 := wb_reg_rs2

--- a/src/main/scala/tile.scala
+++ b/src/main/scala/tile.scala
@@ -84,7 +84,7 @@ class RocketTile(resetSignal: Bool = null)(implicit p: Parameters) extends Tile(
       }))
       val dcIF = Module(new SimpleHellaCacheIF()(dcacheParams))
       rocc.io.cmd <> cmdRouter.io.out(i)
-      rocc.io.s := core.io.rocc.s
+      rocc.io.status := core.io.rocc.status
       rocc.io.exception := core.io.rocc.exception
       rocc.io.host_id := io.host.id
       dcIF.io.requestor <> rocc.io.mem

--- a/src/main/scala/util.scala
+++ b/src/main/scala/util.scala
@@ -27,6 +27,17 @@ object Util {
 
   def minUInt(first: UInt, rest: UInt*): UInt =
     minUInt(first +: rest.toSeq)
+
+  def bitpatJoin(a: BitPat, b: BitPat): BitPat =
+    new BitPat(a.value << b.getWidth | b.value,
+               a.mask  << b.getWidth | b.mask,
+               a.getWidth + b.getWidth)
+
+  def bitpatCat(pats: BitPat*): BitPat =
+    pats.reduceLeft(bitpatJoin(_, _))
+
+  def makeBitPat(x: Int, w: Int): BitPat =
+    new BitPat(BigInt(x), BigInt((1 << w) - 1), w)
 }
 
 import Util._


### PR DESCRIPTION
This changes the RoCC FPU interface to a bit more same. It now takes a simplified set of control signals instead of the fully decoded signals. It also takes IEEE floats instead of recoded floats and can accept divide and square root requests. There is a corresponding PR for Hwacha. When combined, all of the Hwacha assembly tests pass.