### PR TITLE
separate btb response mask from the frontend mask

### DIFF
--- a/src/main/scala/btb.scala
+++ b/src/main/scala/btb.scala
@@ -115,8 +115,8 @@ class RASUpdate(implicit p: Parameters) extends BtbBundle()(p) {
 
 //  - "bridx" is the low-order PC bits of the predicted branch (after
 //     shifting off the lowest log(inst_bytes) bits off).
-//  - "resp.mask" provides a mask of valid instructions (instructions are
-//     masked off by the predicted taken branch).
+//  - "mask" provides a mask of valid instructions (instructions are
+//     masked off by the predicted taken branch from the BTB).
 class BTBResp(implicit p: Parameters) extends BtbBundle()(p) {
   val taken = Bool()
   val mask = Bits(width = fetchWidth)

--- a/src/main/scala/frontend.scala
+++ b/src/main/scala/frontend.scala
@@ -131,7 +131,7 @@ class Frontend(implicit p: Parameters) extends CoreModule()(p) with HasL1CachePa
 
   val all_ones = UInt((1 << (fetchWidth+1))-1)
   val msk_pc = if (fetchWidth == 1) all_ones else all_ones << s2_pc(log2Up(fetchWidth) -1+2,2)
-  io.cpu.resp.bits.mask := Mux(s2_btb_resp_valid, msk_pc & s2_btb_resp_bits.mask, msk_pc)
+  io.cpu.resp.bits.mask := msk_pc
   io.cpu.resp.bits.xcpt_if := s2_xcpt_if
 
   io.cpu.btb_resp.valid := s2_btb_resp_valid


### PR DESCRIPTION
It is now the job of the pipeline to monitor the frontend's valid mask (of
instructions) and the BTB's suggested valid mask (based on the prediction it
makes). Some processors may want to ignore or override the BTB's prediction and
thus can supply their own instruction mask.