### PR TITLE
fix leaky assert in nbdcache

### DIFF
--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -822,7 +822,10 @@ class HellaCache(implicit p: Parameters) extends L1HellaCacheModule()(p) {
 
   assert (!(Reg(next=
     (io.cpu.xcpt.ma.ld || io.cpu.xcpt.ma.st || io.cpu.xcpt.pf.ld || io.cpu.xcpt.pf.st)) &&
-    io.cpu.resp.valid), "DCache exception occurred - cache response not killed.")
+    io.cpu.resp.valid &&
+    s2_valid &&
+    Reg(next=s1_req.tag) === io.cpu.resp.bits.tag),
+      "DCache exception occurred - cache response not killed.")
 
   // tags
   def onReset = L1Metadata(UInt(0), ClientMetadata.onReset)

--- a/src/main/scala/nbdcache.scala
+++ b/src/main/scala/nbdcache.scala
@@ -822,9 +822,7 @@ class HellaCache(implicit p: Parameters) extends L1HellaCacheModule()(p) {
 
   assert (!(Reg(next=
     (io.cpu.xcpt.ma.ld || io.cpu.xcpt.ma.st || io.cpu.xcpt.pf.ld || io.cpu.xcpt.pf.st)) &&
-    io.cpu.resp.valid &&
-    s2_valid &&
-    Reg(next=s1_req.tag) === io.cpu.resp.bits.tag),
+    s2_valid_masked),
       "DCache exception occurred - cache response not killed.")
 
   // tags


### PR DESCRIPTION
The assert in nbdcache checks that a valid response from the cache does not have
any exceptions, as it is the job of the pipeline to detect asserts and supply
the kill signal to the cache. However, the assert can be erroneously triggered
by a load that misses in the cache returning and being compared against spurious
exception signals.

This commit checks that the tag of the response matches the tag corresponding to
the exceptions and also checks that the excepting instruction was valid.