### PR TITLE
chisel3 fix to RoCC connections honor last connect

### DIFF
--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -429,7 +429,8 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
   csr.io.prci <> io.prci
   io.fpu.fcsr_rm := csr.io.fcsr_rm
   csr.io.fcsr_flags := io.fpu.fcsr_flags
-  csr.io.rocc <> io.rocc
+  io.rocc.csr <> csr.io.rocc.csr
+  csr.io.rocc.interrupt <> io.rocc.interrupt
   csr.io.pc := wb_reg_pc
   csr.io.uarch_counters.foreach(_ := Bool(false))
   io.ptw.ptbr := csr.io.ptbr


### PR DESCRIPTION
This worked in chisel2 because of weird last connect semantics. See https://github.com/ucb-bar/chisel/issues/699

Chisel3 is more rigorous and so we need to not override all subfields of RoCC.