### PR TITLE
Modify the RoCC interface to include status in the command queue

### DIFF
--- a/src/main/scala/rocc.scala
+++ b/src/main/scala/rocc.scala
@@ -35,6 +35,7 @@ class RoCCCommand(implicit p: Parameters) extends CoreBundle()(p) {
   val inst = new RoCCInstruction
   val rs1 = Bits(width = xLen)
   val rs2 = Bits(width = xLen)
+  val status = new MStatus
 }
 
 class RoCCResponse(implicit p: Parameters) extends CoreBundle()(p) {
@@ -47,7 +48,6 @@ class RoCCInterface(implicit p: Parameters) extends CoreBundle()(p) {
   val resp = Decoupled(new RoCCResponse)
   val mem = new HellaCacheIO()(p.alterPartial({ case CacheName => "L1D" }))
   val busy = Bool(OUTPUT)
-  val status = new MStatus().asInput
   val interrupt = Bool(OUTPUT)
   
   // These should be handled differently, eventually

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -562,7 +562,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
 
   io.rocc.cmd.valid := wb_rocc_val
   io.rocc.exception := wb_xcpt && csr.io.status.xs.orR
-  io.rocc.status := csr.io.status
+  io.rocc.cmd.bits.status := csr.io.status
   io.rocc.cmd.bits.inst := new RoCCInstruction().fromBits(wb_reg_inst)
   io.rocc.cmd.bits.rs1 := wb_reg_wdata
   io.rocc.cmd.bits.rs2 := wb_reg_rs2

--- a/src/main/scala/tile.scala
+++ b/src/main/scala/tile.scala
@@ -71,7 +71,6 @@ class RocketTile(resetSignal: Bool = null)(implicit p: Parameters) extends Tile(
       }))
       val dcIF = Module(new SimpleHellaCacheIF()(dcacheParams))
       rocc.io.cmd <> cmdRouter.io.out(i)
-      rocc.io.status := core.io.rocc.status
       rocc.io.exception := core.io.rocc.exception
       rocc.io.host_id := io.prci.id
       dcIF.io.requestor <> rocc.io.mem


### PR DESCRIPTION
This addresses a bug in which changes in mstatus could
propagate to RoCCs before their time. Existing RoCCs that use
the status port will need to be modified to match this change.

This addresses the first half of #40.