### PR TITLE
Use new Mul/Div parameters vs UseFastMulDiv

### DIFF
--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -22,7 +22,8 @@ case object UseAtomics extends Field[Boolean]
 case object UsePerfCounters extends Field[Boolean]
 case object FastLoadWord extends Field[Boolean]
 case object FastLoadByte extends Field[Boolean]
-case object FastMulDiv extends Field[Boolean]
+case object MulDivUnroll extends Field[Int]
+case object DivEarlyOut extends Field[Boolean]
 case object CoreInstBits extends Field[Int]
 case object CoreDataBits extends Field[Int]
 case object CoreDCacheReqTagBits extends Field[Int]
@@ -43,7 +44,8 @@ trait HasCoreParameters extends HasAddrMapParameters {
   val usingAtomics = p(UseAtomics)
   val usingFDivSqrt = p(FDivSqrt)
   val usingRoCC = !p(BuildRoCC).isEmpty
-  val usingFastMulDiv = p(FastMulDiv)
+  val mulDivUnroll = p(MulDivUnroll)
+  val divEarlyOut = p(DivEarlyOut)
   val fastLoadWord = p(FastLoadWord)
   val fastLoadByte = p(FastLoadByte)
 
@@ -286,8 +288,9 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
   
   // multiplier and divider
   val div = Module(new MulDiv(width = xLen,
-                              unroll = if(usingFastMulDiv) 8 else 1,
-                              earlyOut = usingFastMulDiv))
+                              unroll = mulDivUnroll,
+                              earlyOut = divEarlyOut))
+
   div.io.req.valid := ex_reg_valid && ex_ctrl.div
   div.io.req.bits.dw := ex_ctrl.alu_dw
   div.io.req.bits.fn := ex_ctrl.alu_fn

--- a/src/main/scala/rocket.scala
+++ b/src/main/scala/rocket.scala
@@ -22,7 +22,7 @@ case object UseAtomics extends Field[Boolean]
 case object UsePerfCounters extends Field[Boolean]
 case object FastLoadWord extends Field[Boolean]
 case object FastLoadByte extends Field[Boolean]
-case object MulDivUnroll extends Field[Int]
+case object MulUnroll extends Field[Int]
 case object DivEarlyOut extends Field[Boolean]
 case object CoreInstBits extends Field[Int]
 case object CoreDataBits extends Field[Int]
@@ -44,7 +44,7 @@ trait HasCoreParameters extends HasAddrMapParameters {
   val usingAtomics = p(UseAtomics)
   val usingFDivSqrt = p(FDivSqrt)
   val usingRoCC = !p(BuildRoCC).isEmpty
-  val mulDivUnroll = p(MulDivUnroll)
+  val mulUnroll = p(MulUnroll)
   val divEarlyOut = p(DivEarlyOut)
   val fastLoadWord = p(FastLoadWord)
   val fastLoadByte = p(FastLoadByte)
@@ -288,7 +288,7 @@ class Rocket(implicit p: Parameters) extends CoreModule()(p) {
   
   // multiplier and divider
   val div = Module(new MulDiv(width = xLen,
-                              unroll = mulDivUnroll,
+                              unroll = mulUnroll,
                               earlyOut = divEarlyOut))
 
   div.io.req.valid := ex_reg_valid && ex_ctrl.div


### PR DESCRIPTION
This addresses rocket-chip issue #166 and creates two separate parameters instead of UseFastMulDiv  --  
MulDivUnroll : Int
DivEarlyOut : Boolean